### PR TITLE
fix right-click name error

### DIFF
--- a/MessageBrowser.lua
+++ b/MessageBrowser.lua
@@ -147,7 +147,7 @@ local function getChannelColor(channelID)
 end
 
 local function formatMsg(msg)
-    local text = string.format("|cffffa900%s|r |Hchannel:channel:%s|h[%s]|h [|Hplayer:%s:-1|h%s|h] %s", date("%H:%M:%S", msg.updateTime), msg.channelID, shortChannelName(msg.channel), msg.authorFullName, msg.author, msg.content)
+    local text = string.format("|cffffa900%s|r |Hchannel:channel:%s|h[%s]|h [|Hplayer:%s:0|h%s|h] %s", date("%H:%M:%S", msg.updateTime), msg.channelID, shortChannelName(msg.channel), msg.authorFullName, msg.author, msg.content)
     if msg.count > 1 then
         text = getColoredCount(msg.count)..text
     end


### PR DESCRIPTION
closes issue #6 

- fix C_ChatInfo.IsValidChatLine out-of-range error (expected range is [0 - MAX_UINT32 = 4,294,967,295]) by using 0 instead of -1 as placeholder in the formatMsg function